### PR TITLE
Adding in project = 0 to fix problems with TheGamesDB latest API changes

### DIFF
--- a/Scraper/TheGamesDB.cs
+++ b/Scraper/TheGamesDB.cs
@@ -65,7 +65,11 @@ namespace ProjectLunarUI
                         platform = "33";
                         break;
                     case GameSystems.SegaCD:
+			platform = "0";
+			break;
                     case GameSystems.Unknown:
+			platform = "0";
+			break;
                     default:
                         break;
                 }


### PR DESCRIPTION
Currently the game manager fails due to changes in the API at thegamesdb.net

Without specifying a platform the API will throw a 500 error due to recent changes.